### PR TITLE
Add the support of bootloader policy and oemvar.

### DIFF
--- a/groups/boot-arch/android_ia/AndroidBoard.mk
+++ b/groups/boot-arch/android_ia/AndroidBoard.mk
@@ -140,6 +140,8 @@ $(call dist-for-goals,droidcore,$(fastboot_usb_bin):$(TARGET_PRODUCT)-fastboot-u
 $(call dist-for-goals,droidcore,device/intel/build/testkeys/testkeys_lockdown.txt:test-keys_efi_lockdown.txt)
 $(call dist-for-goals,droidcore,device/intel/build/testkeys/unlock.txt:efi_unlock.txt)
 
+{{#bootloader_policy}}
+{{#blpolicy_use_efi_var}}
 ifeq ($(TARGET_BOOTLOADER_POLICY),$(filter $(TARGET_BOOTLOADER_POLICY),static external))
 # The bootloader policy is not built but is provided statically in the
 # repository or in $(PRODUCT_OUT)/.
@@ -153,7 +155,10 @@ TARGET_ODM_KEY_PAIR := device/intel/build/testkeys/odm
 TARGET_OAK_KEY_PAIR := device/intel/build/testkeys/OAK
 
 $(BOOTLOADER_POLICY_OEMVARS): sign-efi-sig-list
-        $(GEN_BLPOLICY_OEMVARS) -K $(TARGET_ODM_KEY_PAIR) \
+	$(GEN_BLPOLICY_OEMVARS) -K $(TARGET_ODM_KEY_PAIR) \
 		-O $(TARGET_OAK_KEY_PAIR).x509.pem -B $(TARGET_BOOTLOADER_POLICY) \
 		$(BOOTLOADER_POLICY_OEMVARS)
 endif
+{{/blpolicy_use_efi_var}}
+{{/bootloader_policy}}
+

--- a/groups/boot-arch/android_ia/BoardConfig.mk
+++ b/groups/boot-arch/android_ia/BoardConfig.mk
@@ -31,7 +31,8 @@ KERNELFLINGER_ALLOW_UNSUPPORTED_ACPI_TABLE := true
 KERNELFLINGER_USE_WATCHDOG := true
 # Tell Kernelflinger to ignore ACPI RSCI table
 KERNELFLINGER_IGNORE_RSCI := true
-KERNELFLINGER_SSL_LIBRARY := boringssl
+#KERNELFLINGER_SSL_LIBRARY := boringssl
+KERNELFLINGER_SSL_LIBRARY := openssl
 # Specify system verity partition
 #PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/by-name/system
 
@@ -71,3 +72,63 @@ TARGET_RECOVERY_UPDATER_LIBS := libupdater_esp
 TARGET_RECOVERY_UPDATER_EXTRA_LIBS := libcommon_recovery libgpt_static libefivar
 # By default recovery minui expects RGBA framebuffer
 TARGET_RECOVERY_PIXEL_FORMAT := "BGRA_8888"
+
+
+{{#bootloader_policy}}
+{{#blpolicy_use_efi_var}}
+ifneq ({{bootloader_policy}},static)
+BOOTLOADER_POLICY_OEMVARS = $(PRODUCT_OUT)/bootloader_policy-oemvars.txt
+BOARD_FLASHFILES += $(BOOTLOADER_POLICY_OEMVARS)
+BOARD_OEM_VARS += $(BOOTLOADER_POLICY_OEMVARS)
+endif
+{{/blpolicy_use_efi_var}}
+{{/bootloader_policy}}
+
+{{#bootloader_policy}}
+# It activates the Bootloader policy and RMA refurbishing
+# features. TARGET_BOOTLOADER_POLICY is the desired bitmask for this
+# device.
+# * bit 0:
+#   - 0: GVB class B.
+#   - 1: GVB class A.  Device unlock is not permitted.  The only way
+#     to unlock is to use the secured force-unlock mechanism.
+# * bit 1 and 2 defines the minimal boot state required to boot the
+#   device:
+#   - 0x0: BOOT_STATE_RED (GVB default behavior)
+#   - 0x1: BOOT_STATE_ORANGE
+#   - 0x2: BOOT_STATE_YELLOW
+#   - 0x3: BOOT_STATE_GREEN
+# If TARGET_BOOTLOADER_POLICY is equal to 'static' the bootloader
+# policy is not built but is provided statically in the repository.
+# If TARGET_BOOTLOADER_POLICY is equal to 'external' the bootloader
+# policy OEMVARS should be installed manually in
+# $(BOOTLOADER_POLICY_OEMVARS).
+TARGET_BOOTLOADER_POLICY := {{bootloader_policy}}
+# If the following variable is set to false, the bootloader policy and
+# RMA refurbishing features does not use time-based authenticated EFI
+# variables to store the BPM and OAK values.  The BPM value is defined
+# compilation time by the TARGET_BOOTLOADER_POLICY variable.
+TARGET_BOOTLOADER_POLICY_USE_EFI_VAR := {{blpolicy_use_efi_var}}
+ifeq ($(TARGET_BOOTLOADER_POLICY),$(filter $(TARGET_BOOTLOADER_POLICY),0x0 0x2 0x4 0x6))
+# OEM Unlock reporting 1
+ADDITIONAL_DEFAULT_PROPERTIES += \
+	ro.oem_unlock_supported=1
+endif
+ifeq ($(TARGET_BOOTLOADER_POLICY),$(filter $(TARGET_BOOTLOADER_POLICY),static external))
+# The bootloader policy is not generated build time but is supplied
+# statically in the repository or in $(PRODUCT_OUT)/.  If your
+# bootloader policy allows the device to be unlocked, uncomment the
+# following lines:
+# ADDITIONAL_DEFAULT_PROPERTIES += \
+# 	ro.oem_unlock_supported=1
+endif
+{{/bootloader_policy}}
+
+
+{{^bootloader_policy}}
+# OEM Unlock reporting 2
+ADDITIONAL_DEFAULT_PROPERTIES += \
+	ro.oem_unlock_supported=1
+{{/bootloader_policy}}
+
+

--- a/groups/boot-arch/android_ia/option.spec
+++ b/groups/boot-arch/android_ia/option.spec
@@ -1,0 +1,8 @@
+[mixinfo]
+deps = disk-bus
+
+[defaults]
+bootloader_policy = false
+blpolicy_use_efi_var = true
+bootloader_len = 33
+


### PR DESCRIPTION
The scripts is copyied from Cherry Trail used.

JIRA: AIA-406
Test: Device boots to Home screen.
      Device boots to fastboot & recovery mode.
      FDR happens fine.

Signed-off-by: tanminger <ming.tan@intel.com>